### PR TITLE
fix: return any possible error reasons from `greptimedb:is_alive(Client, true)`

### DIFF
--- a/src/greptimedb.erl
+++ b/src/greptimedb.erl
@@ -182,5 +182,7 @@ rpc_write_stream(#{pool := Pool, cli_opts := Options} = _Client) ->
 
 maybe_return_reason({error, Reason}, true) ->
     {false, Reason};
+maybe_return_reason(Error, true) ->
+    {false, Error};
 maybe_return_reason(_, _) ->
     false.


### PR DESCRIPTION
Hi team, 

A tiny improvement for `is_alive(Client, true)`.
I think if a caller requested `ReturnReason`, it's better to ensure the Reason is always returned, even if the error itself doesn't match `{error, Reason}` pattern.

The later may happen in a real world scenario, since grpcbox  also returns `{http_error, _, _}` which doesn't match `{error, Reason}`:  https://github.com/tsloughter/grpcbox/blob/v0.17.1/src/grpcbox_client.erl#L104