### PR TITLE
feat: supports gRPC insertion hints, close #42

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup greptimedb
       run: |
-        GREPTIMEDB_VER=v0.9.0
+        GREPTIMEDB_VER=v0.9.3
         DOWNLOAD_URL=https://github.com/GreptimeTeam/greptimedb
         curl -L ${DOWNLOAD_URL}/releases/download/${GREPTIMEDB_VER}/greptime-linux-amd64-${GREPTIMEDB_VER}.tar.gz -o /tmp/greptimedb-${GREPTIMEDB_VER}-linux-amd64.tar.gz
         mkdir -p /tmp/greptimedb-download

--- a/README.md
+++ b/README.md
@@ -212,7 +212,12 @@ A proper list contains:
 * `endpoints`: List of the GreptimeDB server address in the form of `{http, host, port}`
 * `pool`, `pool_size` etc.: the client pool settings
 * `grpc_opts`: grpxbox [client options](https://github.com/tsloughter/grpcbox#defining-channels)
-* `grpc_hints`: a map for GreptimeDB gRPC insertion hints, for example`#{ <<"append_mode">> => <<"true">> }` to enable append mode when creating tables automatically.
+* `grpc_hints`: a map for GreptimeDB gRPC insertion hints, for example`#{ <<"append_mode">> => <<"true">> }` to enable append mode when creating tables automatically. Valid hints include:
+    * `append_mode`: `true` or `false` to enable append mode, default is `false`,
+    * `ttl`: time to live, the table `ttl` option,
+    * `merge_mode`:  `last_row` or `last_non_null`, default is `last_row`,
+    * `auto_create_table`: `true` or `false`, whether to create tables automatically when writing data, default is `false`,
+    * More about these table options, please read the [doc](https://docs.greptime.com/reference/sql/create/#table-options).
 * `ssl_opts`: when the endpoint scheme is `https`, the ssl options to use(`[]` by default).
 * `auth`:  authentication options,  `{auth, {basic, #{username => <<"greptime_user">>, password => <<"greptime_pwd">>}}}` for example.
 * `timeunit`: Timestamp unit, supports:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Start the client:
       [{endpoints, [{http, "localhost", 4001}]},
        {pool, greptimedb_client_pool},
        {pool_size, 5},
+       {grpc_hints, #{}},
        {pool_type, random},
        {timeunit, ms}].
     {ok, Client} = greptimedb:start_client(Options).
@@ -205,6 +206,7 @@ A proper list contains:
 * `endpoints`: List of the GreptimeDB server address in the form of `{http, host, port}`
 * `pool`, `pool_size` etc.: the client pool settings
 * `grpc_opts`: grpxbox [client options](https://github.com/tsloughter/grpcbox#defining-channels)
+* `grpc_hints`: a map for GreptimeDB gRPC insertion hints, for example`#{ <<"append_mode">> => <<"true">> }` to enable append mode when creating tables automatically.
 * `ssl_opts`: when the endpoint scheme is `https`, the ssl options to use(`[]` by default).
 * `auth`:  authentication options,  `{auth, {basic, #{username => <<"greptime_user">>, password => <<"greptime_pwd">>}}}` for example.
 * `timeunit`: Timestamp unit, supports:

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Stop the client:
     greptimedb:stop_client(Client).
 ```
 
+Check if the client is alive:
+
+```erlang
+    true = greptimedb:is_alive(Client),
+```
+
 Connect GreptimeDB with authentication:
 
 ```erlang

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {deps, [
     {grpcbox, "0.17.1"},
-    {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.7"}}}
+    {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.9"}}}
 ]}.
 
 {grpc, [{protos, "protos"}, {gpb_opts, [{module_name_suffix, "_pb"}]}]}.

--- a/src/greptimedb_worker.erl
+++ b/src/greptimedb_worker.erl
@@ -33,6 +33,7 @@
 -define(CALL_TIMEOUT, 12_000).
 -define(HEALTH_CHECK_TIMEOUT, 1_000).
 -define(REQUEST_TIMEOUT, 10_000).
+-define(GTDB_HINT_HEADER_PREFIX, <<"x-greptime-hint-">>).
 -define(CONNECT_TIMEOUT, 5_000).
 -define(ASYNC_BATCH_SIZE, 100).
 -define(ASYNC_BATCH_TIMEOUT, 100).
@@ -52,7 +53,7 @@ init(Args) ->
     Endpoints = proplists:get_value(endpoints, Args),
     Hints0 = proplists:get_value(grpc_hints, Args, #{}),
     Hints = maps:fold(fun(Key, Value, Acc) ->
-                              Acc#{ <<"x-greptime-hint-", Key/binary>> => Value}
+                              Acc#{<<?GTDB_HINT_HEADER_PREFIX/binary, Key/binary>> => Value}
                       end, #{}, Hints0),
     SslOptions = proplists:get_value(ssl_opts, Args, []),
     Options = proplists:get_value(grpc_opts, Args, #{connect_timeout => ?CONNECT_TIMEOUT}),

--- a/test/greptimedb_SUITE.erl
+++ b/test/greptimedb_SUITE.erl
@@ -200,6 +200,8 @@ t_write(_) ->
         [{endpoints, [{http, "localhost", 4001}]},
          {pool, greptimedb_client_pool},
          {pool_size, 5},
+         %% enable append mode
+         {grpc_hints, #{<<"append_mode">> => <<"true">>}},
          {pool_type, random},
          {auth, {basic, #{username => <<"greptime_user">>, password => <<"greptime_pwd">>}}}],
 


### PR DESCRIPTION
Supports gRPC insertion hints, adds a new option `gprc_hints`.

For example, enable `append_mdoe`:

```erlang
    Options =
        [{endpoints, [{http, "localhost", 4001}]},
         {pool, greptimedb_client_pool},
         {pool_size, 5},
         %% enable append mode
         {grpc_hints, #{<<"append_mode">> => <<"true">>}},
         {pool_type, random},
         {auth, {basic, #{username => <<"greptime_user">>, password => <<"greptime_pwd">>}}}],

    {ok, Client} = greptimedb:start_client(Options),

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new configuration option `grpc_hints` for enhanced flexibility when connecting to GreptimeDB, allowing users to provide insertion hints for gRPC operations.
	- Enabled "append mode" for the gRPC client in the testing suite.

- **Improvements**
	- Upgraded the GreptimeDB software version to v0.9.3, which may include bug fixes and performance enhancements.
	- Updated the `ecpool` library dependency to version 0.5.9 for improved functionality.

- **Bug Fixes**
	- Enhanced state management and request handling in the GenServer module to utilize new hints for improved request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->