### PR TITLE
fix: atom and process leaks

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/src/greptimedb.erl
+++ b/src/greptimedb.erl
@@ -36,7 +36,7 @@
 
 start_client(Options0) ->
     Pool = proplists:get_value(pool, Options0),
-    Options = lists:keydelete(protocol, 1, lists:keydelete(pool, 1, Options0)),
+    Options = lists:keydelete(protocol, 1, Options0),
 
     Client =
         #{pool => Pool,


### PR DESCRIPTION
Previously, the channel name would use `list_to_atom(pid_to_list(self()))`, which leads to
an atom leak.

Not only that, but the `greptime_worker` `gen_server` process did not set `trap_exit` to
true, which means that the `terminate` callback was not called, leaking `grpcbox_channel`
processes.